### PR TITLE
use topological order and handle partial success correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run linters
         run: |
           cargo fmt -- --check
-          cargo clippy
+          cargo clippy -- -D warnings

--- a/project-fixtures/single-place/.rocat-state.yml
+++ b/project-fixtures/single-place/.rocat-state.yml
@@ -44,68 +44,6 @@
       value: game-icon.png
   outputs:
     assetId: 34487854
-- resourceType: experience_thumbnail
-  id: game-thumbnail-1.png
-  inputs:
-    experienceId:
-      ref:
-        - experience
-        - singleton
-        - assetId
-    fileHash:
-      value: c1811300860fcd79a178142a4f4f7aa73198afa3b64a1b3ae19fc50235e7fa75
-    filePath:
-      value: game-thumbnail-1.png
-  outputs:
-    assetId: 50476156
-- resourceType: experience_thumbnail
-  id: game-thumbnail-2.png
-  inputs:
-    experienceId:
-      ref:
-        - experience
-        - singleton
-        - assetId
-    fileHash:
-      value: d36757cf3312ca2683eb597bed3359367861cd3e4f1c71668fef24f86edb3a12
-    filePath:
-      value: game-thumbnail-2.png
-  outputs:
-    assetId: 50476158
-- resourceType: experience_thumbnail
-  id: game-thumbnail-3.png
-  inputs:
-    experienceId:
-      ref:
-        - experience
-        - singleton
-        - assetId
-    fileHash:
-      value: 66c276e730608cac1c95be4dabd9e12303b477fe6091772b3e998067ed6e3da0
-    filePath:
-      value: game-thumbnail-3.png
-  outputs:
-    assetId: 50476181
-- resourceType: experience_thumbnail_order
-  id: singleton
-  inputs:
-    assetIds:
-      refList:
-        - - experience_thumbnail
-          - game-thumbnail-1.png
-          - assetId
-        - - experience_thumbnail
-          - game-thumbnail-2.png
-          - assetId
-        - - experience_thumbnail
-          - game-thumbnail-3.png
-          - assetId
-    experienceId:
-      ref:
-        - experience
-        - singleton
-        - assetId
-  outputs: ~
 - resourceType: place_configuration
   id: start
   inputs:
@@ -118,7 +56,7 @@
       value:
         name: Start name
         description: Start description
-        maxPlayerCount: 50
+        maxPlayerCount: 20
         allowCopying: false
         socialSlotType: Custom
         customSocialSlotCount: 10

--- a/project-fixtures/single-place/.rocat-state.yml
+++ b/project-fixtures/single-place/.rocat-state.yml
@@ -44,6 +44,68 @@
       value: game-icon.png
   outputs:
     assetId: 34487854
+- resourceType: experience_thumbnail
+  id: game-thumbnail-1.png
+  inputs:
+    experienceId:
+      ref:
+        - experience
+        - singleton
+        - assetId
+    fileHash:
+      value: c1811300860fcd79a178142a4f4f7aa73198afa3b64a1b3ae19fc50235e7fa75
+    filePath:
+      value: game-thumbnail-1.png
+  outputs:
+    assetId: 50501388
+- resourceType: experience_thumbnail
+  id: game-thumbnail-2.png
+  inputs:
+    experienceId:
+      ref:
+        - experience
+        - singleton
+        - assetId
+    fileHash:
+      value: d36757cf3312ca2683eb597bed3359367861cd3e4f1c71668fef24f86edb3a12
+    filePath:
+      value: game-thumbnail-2.png
+  outputs:
+    assetId: 50501386
+- resourceType: experience_thumbnail
+  id: game-thumbnail-3.png
+  inputs:
+    experienceId:
+      ref:
+        - experience
+        - singleton
+        - assetId
+    fileHash:
+      value: 66c276e730608cac1c95be4dabd9e12303b477fe6091772b3e998067ed6e3da0
+    filePath:
+      value: game-thumbnail-3.png
+  outputs:
+    assetId: 50501387
+- resourceType: experience_thumbnail_order
+  id: singleton
+  inputs:
+    assetIds:
+      refList:
+        - - experience_thumbnail
+          - game-thumbnail-1.png
+          - assetId
+        - - experience_thumbnail
+          - game-thumbnail-2.png
+          - assetId
+        - - experience_thumbnail
+          - game-thumbnail-3.png
+          - assetId
+    experienceId:
+      ref:
+        - experience
+        - singleton
+        - assetId
+  outputs: ~
 - resourceType: place_configuration
   id: start
   inputs:

--- a/project-fixtures/single-place/rocat.yml
+++ b/project-fixtures/single-place/rocat.yml
@@ -33,6 +33,6 @@ templates:
     start:
       name: Start name
       description: Start description
-      maxPlayerCount: 50
+      maxPlayerCount: 20
       serverFill: { reservedSlots: 10 }
       allowCopying: false

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -558,13 +558,24 @@ pub fn run(project: Option<&str>) -> Result<(), String> {
         }
     };
 
+    // Get our resource manager
     let mut resource_manager =
         ResourceManager::new(Box::new(RobloxResourceManager::new(&project_path)));
+
+    // Get our resource graphs
     let previous_graph = get_previous_graph(project_path.as_path(), &config, deployment_config)?;
     let mut next_graph = get_desired_graph(project_path.as_path(), &config, deployment_config)?;
-    next_graph.resolve(&mut resource_manager, &previous_graph)?;
+
+    // Evaluate the resource graph
+    println!("Evaluating resource graph:\n");
+    let result = next_graph.evaluate(&previous_graph, &mut resource_manager);
+
+    // Save the results to the state file
     let resources = next_graph.get_resource_list();
     save_state(&project_path, &resources)?;
+
+    // If there were errors, return them
+    result?;
 
     Ok(())
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -104,9 +104,7 @@ impl Resource {
             .values()
             .filter_map(|input| match input {
                 Input::Ref(ref input_ref) => Some(vec![input_ref]),
-                Input::RefList(ref input_ref_list) => {
-                    Some(input_ref_list.iter().map(|input_ref| input_ref).collect())
-                }
+                Input::RefList(ref input_ref_list) => Some(input_ref_list.iter().collect()),
                 _ => None,
             })
             .flatten()
@@ -449,7 +447,7 @@ impl ResourceGraph {
         match &previous_graph.get_resource_from_ref(resource_ref) {
             Some(previous_resource) => {
                 let previous_inputs = previous_graph
-                    .resolve_inputs(&previous_resource)?
+                    .resolve_inputs(previous_resource)?
                     .ok_or("Previous graph should be complete.")?;
                 Ok(ResourceDiff {
                     previous_hash: Some(previous_graph.get_inputs_hash(&previous_inputs)?),
@@ -458,14 +456,14 @@ impl ResourceGraph {
                         id: resource.id.clone(),
                         inputs: resource.inputs.clone(),
                         outputs: previous_resource.outputs.clone(),
-                        resource_type: resource.resource_type.clone(),
+                        resource_type: resource.resource_type,
                     },
                 })
             }
             None => Ok(ResourceDiff {
                 previous_hash: None,
                 previous_resource: None,
-                resource: resource.clone(),
+                resource,
             }),
         }
     }


### PR DESCRIPTION
This PR updates the evaluation function to evaluate the resources according to the topological order of the dependency graph. This also handles the case where the dependency graph is cyclical which will now error before evaluation rather than getting stuck in an infinite loop as it would previously do (note there is currently no case where this is possible with the given configuration format).

With the new topological order it is now easier to reason about some edge cases. Specifically, this PR also adds proper support for partial success cases. It will now always update the state file, even if there were errors, and it will not short-circuit after the first error occurs.