### PR TITLE
add support for badges

### DIFF
--- a/project-fixtures/single-place/rocat.yml
+++ b/project-fixtures/single-place/rocat.yml
@@ -57,6 +57,11 @@ templates:
       description: With a description!
       price: 50
       icon: game-pass-1.png
+  badges:
+    myFirstBadge:
+      name: My first badge
+      description: The best badge of all
+      icon: badge-1.png
 
 state:
   remote:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ fn get_app() -> App<'static, 'static> {
                         .help("The deployment to deploy. If not specified, attempts to match the current git branch to each deployment's branches field.")
                         .value_name("DEPLOYMENT")
                         .takes_value(true))
+                .arg(
+                    Arg::with_name("allow_purchases")
+                        .long("allow-purchases")
+                        .help("Gives Rocat permission to make purchases with Robux."))
         )
         .subcommand(
             SubCommand::with_name("destroy")
@@ -85,6 +89,7 @@ pub async fn run_with(args: Vec<String>) -> i32 {
             commands::deploy::run(
                 deploy_matches.value_of("PROJECT"),
                 deploy_matches.value_of("deployment"),
+                deploy_matches.is_present("allow_purchases"),
             )
             .await
         }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -72,7 +72,7 @@ fn tag_commit(
     Ok(tag_count)
 }
 
-pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
+pub async fn run(project: Option<&str>, deployment: Option<&str>, allow_purchases: bool) -> i32 {
     logger::start_action("Loading project:");
     let Project {
         project_path,
@@ -98,7 +98,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
     let mut resource_manager = RobloxResourceManager::new(&project_path);
 
     logger::start_action("Deploying resources:");
-    let results = next_graph.evaluate(&previous_graph, &mut resource_manager);
+    let results = next_graph.evaluate(&previous_graph, &mut resource_manager, allow_purchases);
     match &results {
         Ok(results) => {
             match results {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -106,6 +106,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
                     created_count: 0,
                     updated_count: 0,
                     deleted_count: 0,
+                    skipped_count: 0,
                     ..
                 } => logger::end_action("No changes required"),
                 EvaluateResults {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -113,9 +113,10 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
                     updated_count,
                     deleted_count,
                     noop_count,
+                    skipped_count,
                 } => logger::end_action(format!(
-                    "Succeeded with {} create(s), {} update(s), {} delete(s), {} noop(s)",
-                    created_count, updated_count, deleted_count, noop_count
+                    "Succeeded with {} create(s), {} update(s), {} delete(s), {} noop(s), {} skip(s)",
+                    created_count, updated_count, deleted_count, noop_count, skipped_count
                 )),
             };
         }

--- a/src/commands/destroy.rs
+++ b/src/commands/destroy.rs
@@ -36,7 +36,7 @@ pub async fn run(project: Option<&str>, deployment: Option<&str>) -> i32 {
 
     logger::start_action("Destroying resources:");
     let mut next_graph = ResourceGraph::new(&Vec::new());
-    let results = next_graph.evaluate(&previous_graph, &mut resource_manager);
+    let results = next_graph.evaluate(&previous_graph, &mut resource_manager, false);
     match &results {
         Ok(results) => {
             match results {

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,9 +76,11 @@ pub struct TemplateConfig {
 
     pub places: Option<HashMap<String, PlaceTemplateConfig>>,
 
+    pub products: Option<HashMap<String, DeveloperProductConifg>>,
+
     pub passes: Option<HashMap<String, PassTemplateConfig>>,
 
-    pub products: Option<HashMap<String, DeveloperProductConifg>>,
+    pub badges: Option<HashMap<String, BadgeConfig>>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -133,6 +135,15 @@ pub struct PassTemplateConfig {
     pub description: Option<String>,
     pub icon: Option<String>,
     pub price: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BadgeConfig {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub icon: Option<String>,
+    pub enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -30,6 +30,8 @@ pub mod resource_types {
     pub const PLACE_CONFIGURATION: &str = "placeConfiguration";
     pub const GAME_PASS: &str = "gamePass";
     pub const GAME_PASS_ICON: &str = "gamePassIcon";
+    pub const BADGE: &str = "badge";
+    pub const BADGE_ICON: &str = "badgeIcon";
 }
 
 pub const SINGLETON_RESOURCE_ID: &str = "singleton";
@@ -203,6 +205,17 @@ impl RobloxResourceManager {
 }
 
 impl ResourceManager for RobloxResourceManager {
+    fn get_price(
+        &mut self,
+        resource_type: &str,
+        _resource_inputs: serde_yaml::Value,
+    ) -> Result<Option<u32>, String> {
+        match resource_type {
+            resource_types::BADGE => Ok(Some(100)),
+            _ => Ok(None),
+        }
+    }
+
     fn create(
         &mut self,
         resource_type: &str,

--- a/src/resource_manager.rs
+++ b/src/resource_manager.rs
@@ -205,7 +205,7 @@ impl RobloxResourceManager {
 }
 
 impl ResourceManager for RobloxResourceManager {
-    fn get_price(
+    fn get_create_price(
         &mut self,
         resource_type: &str,
         _resource_inputs: serde_yaml::Value,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -466,7 +466,7 @@ impl ResourceGraph {
                     Err(error) => OperationResult::Failed(error),
                 }
             }
-            Some(previous_hash) if previous_hash.to_owned() != inputs_hash => {
+            Some(previous_hash) if *previous_hash != inputs_hash => {
                 // This resource has changed
                 logger::start_action(format!(
                     "{} Updating: {} {}",
@@ -474,7 +474,7 @@ impl ResourceGraph {
                     resource.resource_type,
                     resource.id
                 ));
-                logger::log_changeset(get_changeset(&previous_hash, &inputs_hash));
+                logger::log_changeset(get_changeset(previous_hash, &inputs_hash));
 
                 let inputs = match serde_yaml::to_value(inputs) {
                     Ok(v) => v,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -54,22 +54,6 @@ impl Resource {
         self
     }
 
-    pub fn add_output<T>(&mut self, name: &str, output_value: &T) -> Result<&mut Self, String>
-    where
-        T: serde::Serialize,
-    {
-        if self.outputs.is_none() {
-            self.outputs = Some(BTreeMap::new());
-        }
-        let serialized_value = serde_yaml::to_value(output_value)
-            .map_err(|e| format!("Failed to serialize output value:\n\t{}", e))?;
-        self.outputs
-            .as_mut()
-            .unwrap()
-            .insert(name.to_owned(), serialized_value);
-        Ok(self)
-    }
-
     pub fn get_ref(&self) -> ResourceRef {
         (self.resource_type.clone(), self.id.clone())
     }
@@ -138,6 +122,12 @@ pub fn output_name_from_input_ref(input_ref: &InputRef) -> String {
     input_ref_output.clone()
 }
 pub trait ResourceManager {
+    fn get_price(
+        &mut self,
+        resource_type: &str,
+        resource_inputs: serde_yaml::Value,
+    ) -> Result<Option<u32>, String>;
+
     fn create(
         &mut self,
         resource_type: &str,
@@ -182,6 +172,19 @@ pub struct EvaluateResults {
     pub updated_count: u32,
     pub deleted_count: u32,
     pub noop_count: u32,
+    pub skipped_count: u32,
+}
+
+enum OperationType {
+    Create,
+    Update,
+}
+
+enum OperationResult {
+    Skipped,
+    Noop,
+    Failed(String),
+    Succeeded(OperationType, Option<BTreeMap<String, OutputValue>>),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -357,6 +360,128 @@ impl ResourceGraph {
         }
     }
 
+    fn evaluate_create_or_update<TManager>(
+        &self,
+        resource_manager: &mut TManager,
+        resource_diff: &ResourceDiff,
+    ) -> OperationResult
+    where
+        TManager: ResourceManager,
+    {
+        let ResourceDiff {
+            previous_hash,
+            resource,
+            ..
+        } = resource_diff;
+
+        let resolved_inputs = match self.resolve_inputs(&resource_diff.resource) {
+            Ok(v) => v,
+            Err(e) => return OperationResult::Failed(e),
+        };
+
+        let inputs = match resolved_inputs {
+            Some(v) => v,
+            None => return OperationResult::Skipped,
+        };
+
+        let inputs_hash = match self.get_inputs_hash(&inputs) {
+            Ok(v) => v,
+            Err(e) => return OperationResult::Failed(e),
+        };
+
+        // TODO: improve DRY here
+        match previous_hash {
+            None => {
+                // This resource is new
+                logger::start_action(format!(
+                    "{} Creating: {} {}",
+                    Paint::green("+"),
+                    resource.resource_type,
+                    resource.id
+                ));
+                logger::log_changeset(get_changeset("", &inputs_hash));
+
+                let inputs = match serde_yaml::to_value(inputs) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return OperationResult::Failed(format!(
+                            "Unable to serialize inputs: {}",
+                            e
+                        ))
+                    }
+                };
+                match resource_manager.create(&resource.resource_type, inputs) {
+                    Ok(Some(outputs)) => {
+                        let outputs = match serde_yaml::from_value::<BTreeMap<String, OutputValue>>(
+                            outputs,
+                        ) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                return OperationResult::Failed(format!(
+                                    "Unable to deserialize outputs: {}",
+                                    e
+                                ))
+                            }
+                        };
+                        OperationResult::Succeeded(OperationType::Create, Some(outputs))
+                    }
+                    Ok(None) => OperationResult::Succeeded(OperationType::Create, None),
+                    Err(error) => OperationResult::Failed(error),
+                }
+            }
+            Some(previous_hash) if previous_hash.to_owned() != inputs_hash => {
+                // This resource has changed
+                logger::start_action(format!(
+                    "{} Updating: {} {}",
+                    Paint::yellow("~"),
+                    resource.resource_type,
+                    resource.id
+                ));
+                logger::log_changeset(get_changeset(&previous_hash, &inputs_hash));
+
+                let inputs = match serde_yaml::to_value(inputs) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return OperationResult::Failed(format!(
+                            "Unable to serialize inputs: {}",
+                            e
+                        ))
+                    }
+                };
+                let outputs = resource.outputs.clone().unwrap_or_default();
+                let outputs = match serde_yaml::to_value(outputs) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return OperationResult::Failed(format!(
+                            "Unable to serialize outputs: {}",
+                            e
+                        ))
+                    }
+                };
+
+                match resource_manager.update(&resource.resource_type, inputs, outputs) {
+                    Ok(Some(outputs)) => {
+                        let outputs = match serde_yaml::from_value::<BTreeMap<String, OutputValue>>(
+                            outputs,
+                        ) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                return OperationResult::Failed(format!(
+                                    "Unable to deserialize outputs: {}",
+                                    e
+                                ))
+                            }
+                        };
+                        OperationResult::Succeeded(OperationType::Update, Some(outputs))
+                    }
+                    Ok(None) => OperationResult::Succeeded(OperationType::Update, None),
+                    Err(error) => OperationResult::Failed(error),
+                }
+            }
+            _ => OperationResult::Noop,
+        }
+    }
+
     pub fn evaluate<TManager>(
         &mut self,
         previous_graph: &ResourceGraph,
@@ -371,124 +496,89 @@ impl ResourceGraph {
         let mut failures_count = 0;
 
         for resource_ref in resource_order {
-            let ResourceDiff {
-                resource,
-                previous_resource,
-                previous_hash,
-            } = self.get_resource_diff(previous_graph, &resource_ref)?;
+            let resource_diff = self.get_resource_diff(previous_graph, &resource_ref)?;
 
-            let resolved_inputs = self.resolve_inputs(&resource)?;
-            if let Some(inputs) = resolved_inputs {
-                // We can proceed to evaluate this resource
-                let inputs_hash = self.get_inputs_hash(&inputs)?;
-                let outputs = match previous_hash {
-                    None => {
-                        // This resource is new
-                        results.created_count += 1;
-                        logger::start_action(format!(
-                            "{} Creating: {} {}",
-                            Paint::green("+"),
-                            resource.resource_type,
-                            resource.id
-                        ));
-                        logger::log_changeset(get_changeset("", &inputs_hash));
-                        Some(
-                            resource_manager.create(
-                                &resource.resource_type,
-                                serde_yaml::to_value(&inputs)
-                                    .map_err(|e| format!("Failed to serialize inputs: {}", e))?,
+            let operation_result = self.evaluate_create_or_update(resource_manager, &resource_diff);
+
+            match operation_result {
+                OperationResult::Succeeded(op_type, outputs) => {
+                    let mut resource_with_outputs = resource_diff.resource.clone();
+                    resource_with_outputs.outputs = outputs.clone();
+                    self.resources.insert(resource_ref, resource_with_outputs);
+
+                    match op_type {
+                        OperationType::Create => results.created_count += 1,
+                        OperationType::Update => results.updated_count += 1,
+                    };
+
+                    match outputs {
+                        None => logger::end_action("Succeeded"),
+                        Some(outputs) => logger::end_action_with_results(
+                            "Succeeded with outputs:",
+                            format_inputs_hash(
+                                &serde_yaml::to_string(&outputs)
+                                    .map_err(|e| format!("Failed to serialize outputs: {}", e))?,
                             ),
-                        )
-                    }
-                    Some(previous_hash) if previous_hash != inputs_hash => {
-                        // This resource has changed
-                        results.updated_count += 1;
-                        logger::start_action(format!(
-                            "{} Updating: {} {}",
-                            Paint::yellow("~"),
-                            resource.resource_type,
-                            resource.id
-                        ));
-                        logger::log_changeset(get_changeset(&previous_hash, &inputs_hash));
-                        let outputs = resource.outputs.clone().unwrap_or_default();
-                        Some(
-                            resource_manager.update(
-                                &resource.resource_type,
-                                serde_yaml::to_value(inputs)
-                                    .map_err(|e| format!("Failed to serialize inputs: {}", e))?,
-                                serde_yaml::to_value(outputs)
-                                    .map_err(|e| format!("Failed to serialize inputs: {}", e))?,
-                            ),
-                        )
-                    }
-                    _ => {
-                        results.noop_count += 1;
-                        None
-                    }
-                };
-
-                if let Some(outputs) = outputs {
-                    // We attempted to create or update the resource
-                    if let Ok(outputs) = outputs {
-                        // We successfully created or updated the resource
-
-                        if let Some(outputs) = outputs {
-                            // Apply the outputs to the resource
-                            logger::end_action_with_results(
-                                "Succeeded with outputs:",
-                                format_inputs_hash(
-                                    &serde_yaml::to_string(&outputs).map_err(|e| {
-                                        format!("Failed to serialize outputs: {}", e)
-                                    })?,
-                                ),
-                            );
-                            let mut resource_with_outputs = resource.clone();
-                            let outputs =
-                                serde_yaml::from_value::<BTreeMap<String, OutputValue>>(outputs)
-                                    .map_err(|e| format!("Failed to deserialize outputs: {}", e))?;
-                            // TODO: how to handle deserialization errors?
-                            for (key, value) in outputs {
-                                resource_with_outputs.add_output(&key, &value)?;
-                            }
-                            self.resources.insert(resource_ref, resource_with_outputs);
-                        } else {
-                            logger::end_action("Succeeded");
-                        }
-                    } else {
-                        // An error occurred while creating or updating the resource. If the
-                        // resource existed previously, we will copy the old version into this
-                        // graph. Otherwise, we will remove this resource from the graph.
-                        // TODO: this may need work for formatting
-                        logger::end_action(format!("Failed: {}", Paint::red(outputs.unwrap_err())));
-                        failures_count += 1;
-                        if let Some(previous_resource) = previous_resource {
-                            self.resources.insert(resource_ref, previous_resource);
-                        } else {
-                            self.resources.remove(&resource_ref);
-                        }
-                    }
-                } else {
+                        ),
+                    };
+                }
+                OperationResult::Noop => {
                     // There was no need to create or update the resource. We will update the graph
                     // with the resource diff (which may include outputs copied from the previous
                     // resoure).
-                    self.resources.insert(resource_ref, resource.clone());
+                    self.resources
+                        .insert(resource_ref, resource_diff.resource.clone());
+
+                    results.noop_count += 1;
+
+                    // logger::log(format!(
+                    //     "{} Noop:     {} {}\n",
+                    //     Paint::new("○").dimmed(),
+                    //     resource_diff.resource.resource_type,
+                    //     resource_diff.resource.id,
+                    // ));
                 }
-            } else {
-                // A dependency of this resource failed to evaluate. If the resource existed
-                // previously, we will copy the old version into this graph. Otherwise, we will
-                // remove this resource from the graph.
-                if let Some(previous_resource) = previous_resource {
-                    self.resources.insert(resource_ref, previous_resource);
-                } else {
-                    self.resources.remove(&resource_ref);
+                OperationResult::Skipped => {
+                    // A dependency of this resource failed to evaluate. If the resource existed
+                    // previously, we will copy the old version into this graph. Otherwise, we will
+                    // remove this resource from the graph.
+                    if let Some(previous_resource) = resource_diff.previous_resource {
+                        self.resources.insert(resource_ref, previous_resource);
+                    } else {
+                        self.resources.remove(&resource_ref);
+                    }
+
+                    results.skipped_count += 1;
+                    logger::log(format!(
+                        "{} Skipping: {} {}\n",
+                        Paint::red("×"),
+                        resource_diff.resource.resource_type,
+                        resource_diff.resource.id,
+                    ));
                 }
-            }
+                OperationResult::Failed(e) => {
+                    // An error occurred while creating or updating the resource. If the
+                    // resource existed previously, we will copy the old version into this
+                    // graph. Otherwise, we will remove this resource from the graph.
+                    if let Some(previous_resource) = resource_diff.previous_resource {
+                        self.resources.insert(resource_ref, previous_resource);
+                    } else {
+                        self.resources.remove(&resource_ref);
+                    }
+
+                    failures_count += 1;
+
+                    // TODO: this may need work for formatting
+                    logger::end_action(format!("Failed: {}", Paint::red(e)));
+                }
+            };
         }
 
         // Iterate over previous resources in reverse order so that leaf resources are removed first
         let mut previous_resource_order = previous_graph.get_topological_order()?;
         previous_resource_order.reverse();
 
+        // TODO: improve error handling for deletes too
         for resource_ref in previous_resource_order.iter() {
             let resource = &previous_graph.get_resource_from_ref(resource_ref).unwrap();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -354,16 +354,12 @@ pub fn get_desired_graph(
                 .name
                 .clone()
                 .ok_or(format!("Missing required field name for pass {}", name))?;
-            let badge_enabled = match badge_config.enabled {
-                Some(enabled) => enabled,
-                None => true,
-            };
 
             let badge_resource = Resource::new(resource_types::BADGE, name)
                 .add_ref_input("experienceId", &experience_asset_id_ref)
                 .add_value_input("name", &badge_name)?
                 .add_value_input("description", &badge_config.description)?
-                .add_value_input("enabled", &badge_enabled)?
+                .add_value_input("enabled", &badge_config.enabled.unwrap_or(true))?
                 .add_value_input("iconFilePath", &badge_icon_file)?
                 .clone();
             resources.push(badge_resource.clone());


### PR DESCRIPTION
This PR adds support for badges. It also adds some features to the resources API so that resources which require Robux purchases are skipped by default and will only be created if a new `--allow-purchases` flag is supplied